### PR TITLE
Fix format of sample-user.yml and change to generic creds

### DIFF
--- a/sample-user.yml
+++ b/sample-user.yml
@@ -1,5 +1,5 @@
-name: Luis Pabon
-sub: id/luis@portworx.com
-email: luis@portworx.com
+name: tenant-a
+email: tenant@tenant-a.com
+sub: tenant@tenant-a.com/tenant
 roles: ["system.user"]
-groups: ["px-engineering", "kubernetes-csi"]
+groups: ["developers"]


### PR DESCRIPTION
**What this PR does / why we need it**:
The current sample file when used fails with the below error:
```
Events:
  Type     Reason                Age                From                                                                               Message
  ----     ------                ----               ----                                                                               -------
  Normal   ExternalProvisioning  14s (x3 over 31s)  persistentvolume-controller                                                        waiting for a volume to be created, either by external provisioner "pxd.portworx.com" or manually created by system administrator
  Normal   Provisioning          2s (x6 over 31s)   pxd.portworx.com_px-csi-ext-67b5489d47-v9fj4_53ca019c-f1dc-4b4c-8db8-540cf1fb46b6  External provisioner is provisioning volume for claim "postgres/postgres-data"
  Warning  ProvisioningFailed    2s (x6 over 31s)   pxd.portworx.com_px-csi-ext-67b5489d47-v9fj4_53ca019c-f1dc-4b4c-8db8-540cf1fb46b6  failed to provision volume with StorageClass "postgres-sc-2": rpc error: code = PermissionDenied desc = signature is invalid
```

Correcting the format of the file and making it generic.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

